### PR TITLE
Fixing typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Basic Usage
         s = seria.load(f)
         print s.dump('xml')
         print s.dump('json')
-        print s.dump('yml')
+        print s.dump('yaml')
 
 CLI Tool
 -----------


### PR DESCRIPTION
Just fixed the yml -> yaml typo in the example code :+1: 
